### PR TITLE
Minor arg num fix and more reduced logging

### DIFF
--- a/minecraft_bot/src/action_schemas.py
+++ b/minecraft_bot/src/action_schemas.py
@@ -105,9 +105,9 @@ def move_toward_block(block_atom):
     cur_map = space_server.get_map(map_handle)
     block_pos = cur_map.get_block_location(block_atom.h)
     if block_pos == None:
-        print 'block postion not found.',block_atom
+        print 'block position not found.',block_atom
         return TruthValue(0,1)
-    dest = get_near_free_point(cur_map, block_pos, 2, (1,0,0), True)
+    dest = get_near_free_point(atomspace, cur_map, block_pos, 2, (1,0,0), True)
 
     if dest == None:
         print 'get_no_free_point'

--- a/minecraft_bot/src/attention_module.py
+++ b/minecraft_bot/src/attention_module.py
@@ -71,14 +71,16 @@ class AttentionController:
                                       ).h)
         disappeared_atom = Atom(disappeared_handle, self._atomspace)
         all_eval_links = new_atom.out + disappeared_atom.out
+        print "Found %s new blocks." % len(new_atom.out)
+        print "Found %s disappeared blocks." % len(disappeared_atom.out)
         for eval_link in all_eval_links:
             atom = eval_link.out[1]
             cur_sti = atom.av['sti']
-            print cur_sti
+            #print cur_sti
             self._atomspace.set_av(atom.h, sti=cur_sti + 5)
-            print atom
+            #print atom
             self._atomspace.remove(eval_link)
         for block in self._atomspace.get_atoms_by_type(types.StructureNode):
             cur_sti = block.av['sti']
             self._atomspace.set_av(block.h, sti=cur_sti - 1)
-            print block
+            #print block

--- a/minecraft_bot/src/attention_module.py
+++ b/minecraft_bot/src/attention_module.py
@@ -80,6 +80,7 @@ class AttentionController:
             self._atomspace.set_av(atom.h, sti=cur_sti + 5)
             #print atom
             self._atomspace.remove(eval_link)
+        print len(self._atomspace.get_atoms_by_type(types.StructureNode)), " Structure Nodes in AtomSpace."
         for block in self._atomspace.get_atoms_by_type(types.StructureNode):
             cur_sti = block.av['sti']
             self._atomspace.set_av(block.h, sti=cur_sti - 1)

--- a/minecraft_bot/src/opencog_initializer.py
+++ b/minecraft_bot/src/opencog_initializer.py
@@ -29,7 +29,12 @@ ag = ActionGenerator(spacetime.get_atomspace(),
                      spacetime.get_time_server())
 ac = AttentionController(spacetime.get_atomspace())
 
+time_step = 1
+
 while not rospy.is_shutdown():
+    print "\n\nTime Step: ", time_step
+    time_step += 1
+
     ac.control_av_in_atomspace()
     ag.generate_action()
     rospy.sleep(0.8)


### PR DESCRIPTION
The arg num fix is for the situation when a gold_ore block is detected, although it will still crash out due to the missing get_self_agent_entity call.  The reduced logging merely prints a summary of new and deleted blocks in the atomspace, rather than printing the full list of block atoms.