### PR TITLE
Fix corresponding to re-opened issue #20

### DIFF
--- a/minecraft_bot/__init__.py
+++ b/minecraft_bot/__init__.py
@@ -1,5 +1,9 @@
 # minecraft_bot/__init__.py
 # ! /usr/bin/env python2.7 python2 python
+import msg
+import src
+import srv
+
 __author__ = "Karan Desai"
 
 __all__ = ["msg", "src", "srv"]

--- a/spockextras/__init__.py
+++ b/spockextras/__init__.py
@@ -1,0 +1,8 @@
+# minecraft_bot/__init__.py
+# ! /usr/bin/env python2.7 python2 python
+import plugins
+from plugins import *
+
+__author__ = "Karan Desai"
+
+__all__ = ["plugins", "event", "inventory"]

--- a/spockextras/plugins/__init__.py
+++ b/spockextras/plugins/__init__.py
@@ -1,0 +1,5 @@
+# minecraft_bot/__init__.py
+# ! /usr/bin/env python2.7 python2 python
+__author__ = "Karan Desai"
+
+__all__ = ["cores", "helpers"]

--- a/spockextras/plugins/cores/__init__.py
+++ b/spockextras/plugins/cores/__init__.py
@@ -1,0 +1,5 @@
+# minecraft_bot/__init__.py
+# ! /usr/bin/env python2.7 python2 python
+__author__ = "Karan Desai"
+
+__all__ = ["NewNet"]

--- a/spockextras/plugins/helpers/__init__.py
+++ b/spockextras/plugins/helpers/__init__.py
@@ -1,0 +1,7 @@
+# minecraft_bot/__init__.py
+# ! /usr/bin/env python2.7 python2 python
+__author__ = "Karan Desai"
+
+__all__ = ["entities", "MapInit", "Messenger", "MineAndPlace", "NewMovement",
+           "NewPhysics", "Runaway", "SendEntityData", "SendMapData",
+           "SpockControl"]


### PR DESCRIPTION
* Adds **\__all\__** lists in `__init__.py` files of spockextras directory and sub-directories.

* The main remedy which fixes the bug is to import all the modules of a certain directory in the `__init__.py` file corresponding to that directory.

* This means, for say, **minecraft_bot** :

* Addition in `__init__.py` of minecraft_bot would be :
```
import msg, src, srv
```
* This means importing all modules present in current module. Done for all the modules and submodules.

* This ensures that we can do :
```
import minecraft_bot

foo = minecraft_bot.Foo()
bar = minecraft_bot.src.Bar()
foobar = minecraft_bot.src.foo_bar.FooBar()
```

and does not require separate imports like :
```
import minecraft_bot
from minecraft_bot import src
from minecraft_bot.src import foo_bar

foo = minecraft_bot.Foo()
bar = minecraft_bot.src.Bar()
foobar = minecraft_bot.src.foo_bar.FooBar()
```
